### PR TITLE
Enable trailing slash in Docusaurus configuration

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -19,7 +19,7 @@ const config: Config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "hi120ki", // Usually your GitHub org/user name.
   projectName: "hi120ki.github.io", // Usually your repo name.
-  trailingSlash: false,
+  trailingSlash: true,
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",


### PR DESCRIPTION
## Summary
- Changed `trailingSlash` from `false` to `true` in `docusaurus.config.ts`
- This ensures consistent URL formatting across the site with trailing slashes

## Test plan
- [ ] Verify site builds successfully
- [ ] Check that URLs now include trailing slashes
- [ ] Confirm navigation works properly with the new configuration

🤖 Generated with [Claude Code](https://claude.ai/code)