### PR TITLE
fix: update markdown link formatting in Japanese MCP auth blog post

### DIFF
--- a/i18n/ja/docusaurus-plugin-content-blog/2025-07-28-mcp-auth.md
+++ b/i18n/ja/docusaurus-plugin-content-blog/2025-07-28-mcp-auth.md
@@ -65,7 +65,7 @@ OktaはDynamic Client Registration自体はサポートしますが、管理者�
 
 ではAtlassianのRemote MCP Serverはどのように追加のクレデンシャルなしにDynamic Client Registrationをサポートしているのでしょうか。彼らは独自にDynamic Client Registrationを実装したAuthorization Serverを提供しています。
 
-AtlassianはOAuth 2.1ベースのASメタデータを公開しており、Remote MCP Serverの接続開始時にブラウザ経由のOAuthフローへ誘導されます（https://mcp.atlassian.com/v1/sseが、ここでAtlassianはMCP専用の認可サーバーを提供し、そこからさらに本来のAtlassianアカウントのエコシステムを構成している認可サーバーを利用しています。
+AtlassianはOAuth 2.1ベースのASメタデータを公開しており、Remote MCP Serverの接続開始時にブラウザ経由のOAuthフローへ誘導されます(<https://mcp.atlassian.com/v1/sse>)が、ここでAtlassianはMCP専用の認可サーバーを提供し、そこからさらに本来のAtlassianアカウントのエコシステムを構成している認可サーバーを利用しています。
 
 この2つの認可サーバーを組み合わせて利用する方式は現在よく取り入れられており、もし自身で試したい場合は[remote-mcp-github-oauth - Cloudflare AI](https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-github-oauth)でその詳細を学ぶことができます。[workers-oauth-provider](https://github.com/cloudflare/workers-oauth-provider)というCloudflareが提供しているOAuth providerを構成するためのライブラリを利用し、独自にDynamic Client Registrationを構成し提供することができます。
 


### PR DESCRIPTION
## Summary
- Fixed markdown link formatting in Japanese MCP auth blog post
- Updated URL from parentheses to angle brackets for proper rendering

## Test plan
- [ ] Verify markdown link renders properly in documentation site
- [ ] Confirm Japanese content displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)