### PR TITLE
Add Claude Code Organization Settings to homepage timeline

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -192,6 +192,15 @@ export default function Home(): ReactNode {
                 ],
               },
               {
+                text: "Distributed and enforced Claude Code security settings organization-wide via MDM, applying role-based controls tailored for both developers and non-developers.",
+                publications: [
+                  {
+                    title: "Claude Code Organization Settings",
+                    url: "https://speakerdeck.com/hi120ki/claude-code-organization-settings",
+                  },
+                ],
+              },
+              {
                 text: "Designed automated security check architecture for n8n AI workflows and mentored a junior engineer through implementation. Built a secure Devin Enterprise management platform in Go and GitHub Actions, including a custom Terraform provider, automated secret rotation, and API key lifecycle controls.",
                 publications: [
                   {


### PR DESCRIPTION
## Summary
- Add a new entry under the May 2025 - Present Mercari AI Security role describing MDM-based organization-wide distribution of Claude Code security settings
- Link to the Speaker Deck talk: https://speakerdeck.com/hi120ki/claude-code-organization-settings

## Test plan
- [ ] Verify the homepage renders the new timeline entry with working link

🤖 Generated with [Claude Code](https://claude.com/claude-code)