### PR TITLE
Silence TypeScript baseUrl deprecation warning

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0"
   },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## Summary
- Add `ignoreDeprecations: "6.0"` to tsconfig.json to silence the TS 6.x deprecation warning for `baseUrl`
- Keep `baseUrl: "."` as required by Docusaurus so the `@site/*` path alias still resolves to the project root

## Test plan
- [ ] `npx tsc --noEmit` completes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)