### PR TITLE
Add lastmod field to sitemap.xml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -21,6 +21,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -38,6 +38,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: "./sidebars.ts",
+          showLastUpdateTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           // editUrl:
@@ -45,6 +46,7 @@ const config: Config = {
         },
         blog: {
           showReadingTime: true,
+          showLastUpdateTime: true,
           feedOptions: {
             type: ["rss", "atom"],
             xslt: true,
@@ -57,6 +59,9 @@ const config: Config = {
           onInlineTags: "warn",
           onInlineAuthors: "warn",
           onUntruncatedBlogPosts: "warn",
+        },
+        sitemap: {
+          lastmod: "date",
         },
         theme: {
           customCss: "./src/css/custom.css",


### PR DESCRIPTION
## Summary
- Set `sitemap.lastmod: "date"` and enable `showLastUpdateTime` on docs/blog so `<lastmod>` is emitted for content pages (aggregate pages like tags/archive/pagination are intentionally skipped per Google's guidance)
- Add `fetch-depth: 0` to both workflows since `lastUpdatedAt` is derived from git history and shallow clones break it

## Test plan
- [x] `npm run build` locally: 87/149 URLs in `build/sitemap.xml` have `<lastmod>`; dates match `git log -1 -- <file>`
- [ ] Verify CI (`test-deploy`) passes on this PR
- [ ] After merge, confirm `https://hi120ki.github.io/sitemap.xml` contains `<lastmod>` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)