### PR TITLE
Add References section to AI security second-half blog post

### DIFF
--- a/blog/2026-07-01-ai-security-second-half.md
+++ b/blog/2026-07-01-ai-security-second-half.md
@@ -108,3 +108,10 @@ Many of the items I wrote at the start of the year as needing to "wait for futur
 Because much of AI Security work is foundational and easy to standardize, I feel it is equally important to document and share what you've implemented and deploy it with scalability in mind, while also making the impact visible alongside easy-to-understand metrics such as CIS benchmark achievement rates.
 
 I hope to make progress on various initiatives so that I can write the next installment half a year from now. Thank you for reading this far.
+
+## References
+
+- [AI Security Challenges in 2026](https://hi120ki.github.io/blog/posts/20260103/)
+- [Action Items for Agent Platform Security](https://hi120ki.github.io/blog/posts/20260223/)
+- [How Secure Are Claude Managed Agents?](https://hi120ki.github.io/blog/posts/20260413/)
+- [4 Insights from My First Year as an AI Security Engineer](https://hi120ki.github.io/blog/posts/20260524/)

--- a/i18n/ja/docusaurus-plugin-content-blog/2026-07-01-ai-security-second-half.md
+++ b/i18n/ja/docusaurus-plugin-content-blog/2026-07-01-ai-security-second-half.md
@@ -108,3 +108,10 @@ Anthropicは重要ソフトウェアをAI時代に向けて堅牢化する[Proje
 AI Securityの取り組みは、基盤的で共通化しやすいものが多いからこそ、実施した内容をドキュメント化して発信しスケーラビリティを意識した展開をするとともに、CISベンチマークの達成率のような分かりやすい指標とあわせて、インパクトが見える形にしていくことも同じくらい重要だと感じています。
 
 半年後にまたこの続きを書けるよう様々な取り組みを進めたいと思います。ここまで読んでいただき、ありがとうございました。
+
+## 参考
+
+- [2026年のAI Securityの挑戦](https://hi120ki.github.io/ja/blog/posts/20260103/)
+- [Agent Platformに必要なセキュリティ対策まとめ](https://hi120ki.github.io/ja/blog/posts/20260223/)
+- [Claude Managed Agentsはどこまで安全か？](https://hi120ki.github.io/ja/blog/posts/20260413/)
+- [AIセキュリティエンジニアが1年で得た4つの洞察](https://hi120ki.github.io/ja/blog/posts/20260524/)


### PR DESCRIPTION
## Summary

Adds a References section below the Conclusion (`最後に` in Japanese) of the 2026-07-01 post, linking to the four related 2026 articles for internal linking and SEO.

- **English** (`## References`) and **Japanese** (`## 参考`), matching the existing convention used in other posts.
- Japanese titles pulled verbatim from each post's frontmatter; Japanese links use the `/ja/` URL prefix.

Links added:
- AI Security Challenges in 2026 — `posts/20260103`
- Action Items for Agent Platform Security — `posts/20260223`
- How Secure Are Claude Managed Agents? — `posts/20260413`
- 4 Insights from My First Year as an AI Security Engineer — `posts/20260524`

## Test plan

- [ ] Verify the References links resolve correctly on the rendered site (EN and JA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YZNScCcLsVr7AXCu9cuSq